### PR TITLE
[FEATURE] Inline MM processing allowed

### DIFF
--- a/Classes/Domain/Repository/CommonRepository.php
+++ b/Classes/Domain/Repository/CommonRepository.php
@@ -1453,7 +1453,16 @@ class CommonRepository extends BaseRepository
                 '',
                 'uid_local,uid_foreign'
             ),
-            $this->findPropertiesByProperty($this->foreignDatabase, 'uid_local', $recordIdentifier, '','','','','uid_local,uid_foreign')
+            $this->findPropertiesByProperty(
+                $this->foreignDatabase,
+                'uid_local',
+                $recordIdentifier,
+                '',
+                '',
+                '',
+                '',
+                'uid_local,uid_foreign'
+            )
         );
         $this->fetchOriginalRecordsForInlineRecord(
             $relationRecords,

--- a/Classes/Domain/Repository/CommonRepository.php
+++ b/Classes/Domain/Repository/CommonRepository.php
@@ -1446,9 +1446,14 @@ class CommonRepository extends BaseRepository
             $this->findPropertiesByProperty(
                 $this->localDatabase,
                 'uid_local',
-                $recordIdentifier
+                $recordIdentifier,
+                '',
+                '',
+                '',
+                '',
+                'uid_local,uid_foreign'
             ),
-            $this->findPropertiesByProperty($this->foreignDatabase, 'uid_local', $recordIdentifier)
+            $this->findPropertiesByProperty($this->foreignDatabase, 'uid_local', $recordIdentifier, '','','','','uid_local,uid_foreign')
         );
         $this->fetchOriginalRecordsForInlineRecord(
             $relationRecords,

--- a/Classes/Domain/Service/Processor/InlineProcessor.php
+++ b/Classes/Domain/Service/Processor/InlineProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace In2code\In2publishCore\Domain\Service\Processor;
 
 /***************************************************************
@@ -50,7 +51,6 @@ class InlineProcessor extends AbstractProcessor
      * @var array
      */
     protected $required = array(
-        'the foreign_field tells the field where to find the uid pointing to the relation' => self::FOREIGN_FIELD,
         'Must be set, there is no type "inline" without a foreign table' => self::FOREIGN_TABLE,
     );
 
@@ -58,6 +58,7 @@ class InlineProcessor extends AbstractProcessor
      * @var array
      */
     protected $allowed = array(
+        self::FOREIGN_FIELD,
         self::FOREIGN_MATCH_FIELDS,
         self::FOREIGN_TABLE_FIELD,
         self::MM
@@ -70,8 +71,11 @@ class InlineProcessor extends AbstractProcessor
     public function canPreProcess(array $config)
     {
         parent::canPreProcess($config);
-        if (isset($this->lastReasons[self::FOREIGN_FIELD]) && array_key_exists(self::MM, $config)) {
-            unset($this->lastReasons[self::FOREIGN_FIELD]);
+        if (array_key_exists(self::MM, $config) && array_key_exists(self::FOREIGN_FIELD, $config)) {
+            $this->lastReasons[self::FOREIGN_FIELD] = 'the foreign_field is not allowed here because of given MM table';
+        }
+        if (!(array_key_exists(self::MM, $config) || array_key_exists(self::FOREIGN_FIELD, $config))) {
+            $this->lastReasons[self::FOREIGN_FIELD] = 'foreign_field or MM table must be set for type "inline"';
         }
 
         return empty($this->lastReasons);

--- a/Classes/Domain/Service/Processor/InlineProcessor.php
+++ b/Classes/Domain/Service/Processor/InlineProcessor.php
@@ -34,6 +34,7 @@ class InlineProcessor extends AbstractProcessor
     const FOREIGN_FIELD = 'foreign_field';
     const FOREIGN_MATCH_FIELDS = 'foreign_match_fields';
     const FOREIGN_TABLE_FIELD = 'foreign_table_field';
+    const MM = 'MM';
 
     /**
      * @var bool
@@ -59,5 +60,20 @@ class InlineProcessor extends AbstractProcessor
     protected $allowed = array(
         self::FOREIGN_MATCH_FIELDS,
         self::FOREIGN_TABLE_FIELD,
+        self::MM
     );
+
+    /**
+     * @param array $config
+     * @return bool
+     */
+    public function canPreProcess(array $config)
+    {
+        parent::canPreProcess($config);
+        if (isset($this->lastReasons[self::FOREIGN_FIELD]) && array_key_exists(self::MM, $config)) {
+            unset($this->lastReasons[self::FOREIGN_FIELD]);
+        }
+
+        return empty($this->lastReasons);
+    }
 }

--- a/Classes/Domain/Service/Processor/InlineProcessor.php
+++ b/Classes/Domain/Service/Processor/InlineProcessor.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace In2code\In2publishCore\Domain\Service\Processor;
 
 /***************************************************************


### PR DESCRIPTION
Hello,

we discovered a problem with an additional page field configured as inline m:n relation.
This is the relation configuration of the field:
```
'config' => [
            'type' => 'inline',
            'foreign_table' => 'tx_smssystems_domain_model_relation',
            'MM' => 'tx_smssystems_pages_relation_mm',
```
The MM table has two keys `uid_local` and `uid_foreign` as usual, no uid field.

Records related to this page field are published, but the relation itself is not transferred. The needed inserts in the mm tables are missing in the live system.

To solve this problem we first modified the InlineProcessor class to allow the 'MM' config property. If this config entry is set, the FOREIGN_FIELD config entry is not required anymore and is unset. This needs to be done because otherwise the inline field configuration is put into the incompatible TCA configuration (FOREIGN_FIELD is missing) and on the other hand the method `fetchRelatedRecordsByInlineMm` in the CommonRepository class would log an error (line 1434).

The second modification is in the `fetchRelatedRecordsByInlineMm` method itself when `findPropertiesByProperty` is called with a missing (better: with the wrong default value "uid") value for the parameter `indexField`. In the m:n-relations the `indexField` is a combination of `uid_local` and `uid_foreign` of the mm-table and therefore the value for the indexField parameter is "uid_local,uid_foreign" (line 1454, 1456).

Now the Publish Overview module correctly shows all relations to this field, the records and the mm-table entries (the model above even contains properties with other m:n-relations which all are shown correctly in the list). All records and relations are published successfully to the live system.

Could you please check this pull request and tell us if this works for you too? We absolutly need a way to publish inline m:n relations belonging to a custom page field.

Thanks again ;)