### PR TITLE
[FEATURE] allow usage of nav_title in record index view

### DIFF
--- a/Classes/Config/Definer/In2publishCoreDefiner.php
+++ b/Classes/Config/Definer/In2publishCoreDefiner.php
@@ -201,6 +201,7 @@ class In2publishCoreDefiner implements DefinerInterface
                                      Builder::start()
                                             ->addBoolean('filterButtons', true)
                                  )
+                                 ->addString('titleField', 'title')
                       )
                       ->addArray(
                           'module',

--- a/Classes/Controller/ToolsController.php
+++ b/Classes/Controller/ToolsController.php
@@ -162,8 +162,12 @@ class ToolsController extends ActionController
     public function flushEnvelopesAction()
     {
         GeneralUtility::makeInstance(Letterbox::class)->removeAnsweredEnvelopes();
-        $this->addFlashMessage(LocalizationUtility::translate('module.m4.superfluous_envelopes_flushed',
-            'in2publish_core'));
+        $this->addFlashMessage(
+            LocalizationUtility::translate(
+                'module.m4.superfluous_envelopes_flushed',
+                'in2publish_core'
+            )
+        );
         try {
             $this->redirect('index');
         } catch (UnsupportedRequestTypeException $e) {

--- a/Classes/Controller/ToolsController.php
+++ b/Classes/Controller/ToolsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace In2code\In2publishCore\Controller;
 
 /***************************************************************
@@ -161,7 +162,8 @@ class ToolsController extends ActionController
     public function flushEnvelopesAction()
     {
         GeneralUtility::makeInstance(Letterbox::class)->removeAnsweredEnvelopes();
-        $this->addFlashMessage(LocalizationUtility::translate('module.m4.superfluous_envelopes_flushed', 'in2publish_core'));
+        $this->addFlashMessage(LocalizationUtility::translate('module.m4.superfluous_envelopes_flushed',
+            'in2publish_core'));
         try {
             $this->redirect('index');
         } catch (UnsupportedRequestTypeException $e) {

--- a/Classes/Service/Environment/ForeignEnvironmentService.php
+++ b/Classes/Service/Environment/ForeignEnvironmentService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace In2code\In2publishCore\Service\Environment;
 
 /***************************************************************
@@ -69,8 +70,7 @@ class ForeignEnvironmentService
     {
         if ($this->cache
             &&
-            $this->cache->has('foreign_db_init'))
-        {
+            $this->cache->has('foreign_db_init')) {
             return $this->cache->get('foreign_db_init');
         }
 
@@ -101,6 +101,7 @@ class ForeignEnvironmentService
                 ]
             );
         }
+
         return $decodedDbInit;
     }
 
@@ -148,6 +149,7 @@ class ForeignEnvironmentService
 
             $this->cache->set('create_masks', $createMasks, [], 86400);
         }
+
         return (array)$this->cache->get('create_masks');
     }
 
@@ -189,6 +191,7 @@ class ForeignEnvironmentService
                 $values[$key] = $value;
             }
         }
+
         return $values;
     }
 }

--- a/Configuration/Yaml/LocalConfiguration.yaml.example
+++ b/Configuration/Yaml/LocalConfiguration.yaml.example
@@ -227,6 +227,9 @@ view:
     # Activate Filter buttons
     filterButtons: TRUE
 
+  # publish module use as title field (for pages) you can set this f.e. to nav_title
+  titleField: title
+
 
 # SSH and transfer settings for foreign ssh connection (file and commands)
 sshConnection:

--- a/Resources/Private/Partials/Record/Index/PageList.html
+++ b/Resources/Private/Partials/Record/Index/PageList.html
@@ -8,7 +8,7 @@
 		<div class="in2publish-stagelisting__item__column in2publish-stagelisting__item__column--left">
 			<i class="in2publish-icon-folder" title="{f:translate(key:'record.state.{record.stateRecursive}',default:record.stateRecursive)}"></i>
 			<f:if condition="{config.debug.showRecordDepth}">[{record.additionalProperties.depth}]</f:if>
-			<publish:Miscellaneous.GetPropertyFromStagingDefinition record="{record}" propertyName="title" stagingLevel="local" />
+			<publish:Miscellaneous.GetPropertyFromStagingDefinition record="{record}" propertyName="{config.view.titleField}" stagingLevel="local" fallbackProperty="title"/>
 			<i class="in2publish-icon-info" {publish:Attribute.DirtyPropertiesIconDataAttributes(record:record)}></i>
 			<f:if condition="{record.changedRecursive}">
 				<f:if condition="{publish:Condition.IsUserAllowedToPublish()}">
@@ -28,7 +28,7 @@
 		</f:comment>
 		<div class="in2publish-stagelisting__item__column in2publish-stagelisting__item__column--right">
 			<i class="in2publish-icon-folder" title="{f:translate(key:'record.state.{record.stateRecursive}',default:record.stateRecursive)}"></i>
-			<publish:Miscellaneous.GetPropertyFromStagingDefinition record="{record}" propertyName="title" stagingLevel="foreign" />
+			<publish:Miscellaneous.GetPropertyFromStagingDefinition record="{record}" propertyName="{config.view.titleField}" stagingLevel="foreign" fallbackProperty="title" />
 		</div>
 
 		<f:if condition="{config.factory.simpleOverviewAndAjax}">


### PR DESCRIPTION
As an administrator I like to configure, which title field is used
for pages records in publishing overview module.

Activate via yaml configuration:
view:
  titleField: title