### PR TITLE
WIP: Require typo3s cms-core instead of full cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 	"license": "GPL-3.0-or-later",
 	"require": {
 		"php": ">=5.5",
-		"typo3/cms": ">=7.6.0 <9.0.0, !=8.3.0"
+		"typo3/cms-core": ">=7.6.0 <9.0.0, !=8.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8",


### PR DESCRIPTION
Replace the `typo3/cms` dependency by the `typo3/cms-core` one. It prevents all default sysexts to be forced on the typo3 system