### PR TITLE
[BUGFIX] Rename language labels to foreign options

### DIFF
--- a/Configuration/Yaml/LocalConfiguration.yaml.example
+++ b/Configuration/Yaml/LocalConfiguration.yaml.example
@@ -1,10 +1,10 @@
 #
-#    Example Configuration for in2publish
+#    Example Configuration for in2publish on local
 #
 
 ---
 
-# Database access
+# PHP & Database settings on foreign server (for SSH access see "sshConnection")
 foreign:
 
   # root path of the foreign TYPO3 CMS instance

--- a/Resources/Private/Language/de.locallang.testing.xlf
+++ b/Resources/Private/Language/de.locallang.testing.xlf
@@ -175,20 +175,20 @@
 				<target state="translated">Der folgende Fehler wurde von der SSH Verbindung gemeldet:</target>
 			</trans-unit>
 			<trans-unit id="ssh_connection.invalid_php">
-				<source>The path to php seems to be wrong (option: sshConnection.pathToPhp).</source>
-				<target state="translated">Der Pfad zu PHP stimmt möglicherweise nicht (Option: sshConnection.pathToPhp).</target>
+				<source>The path to php seems to be wrong (option: foreign.pathToPhp).</source>
+				<target state="translated">Der Pfad zu PHP stimmt möglicherweise nicht (Option: foreign.pathToPhp).</target>
 			</trans-unit>
 			<trans-unit id="ssh_connection.php_test_error_message">
 				<source>The test returned following error message:</source>
 				<target state="translated">Der Test hat folgende Fehlermeldung zurück gegeben:</target>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_root_wrong">
-				<source>The foreign document root could not be validated, because typical TYPO3 folders are missing (option: sshConnection.foreignRootPath).</source>
-				<target state="translated">Das Webverzeichnis des entfernten Systems konnte nicht verifiziert werden, da typische TYPO3-Verzeichnisse fehlen (Option: sshConnection.foreignRootPath).</target>
+				<source>The foreign document root could not be validated, because typical TYPO3 folders are missing (option: foreign.rootPath).</source>
+				<target state="translated">Das Webverzeichnis des entfernten Systems konnte nicht verifiziert werden, da typische TYPO3-Verzeichnisse fehlen (Option: foreign.rootPath).</target>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_root_missing">
-				<source>The foreign document root could not be validated, because the configured folder "%s" does not exist (option: sshConnection.foreignRootPath).</source>
-				<target state="translated">Das Webverzeichnis des entfernten Systems konnte nicht verifiziert werden, da das konfigurierte Verzeichnis "%s" nicht existiert (Option: sshConnection.foreignRootPath).</target>
+				<source>The foreign document root could not be validated, because the configured folder "%s" does not exist (option: foreign.rootPath).</source>
+				<target state="translated">Das Webverzeichnis des entfernten Systems konnte nicht verifiziert werden, da das konfigurierte Verzeichnis "%s" nicht existiert (Option: foreign.rootPath).</target>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_validation_error">
 				<source>Could not validate the foreign document root for other reasons.</source>

--- a/Resources/Private/Language/locallang.testing.xlf
+++ b/Resources/Private/Language/locallang.testing.xlf
@@ -143,16 +143,16 @@
 				<source>The following error was returned by the ssh connection:</source>
 			</trans-unit>
 			<trans-unit id="ssh_connection.invalid_php">
-				<source>The path to php seems to be wrong (option: sshConnection.pathToPhp).</source>
+				<source>The path to php seems to be wrong (option: foreign.pathToPhp).</source>
 			</trans-unit>
 			<trans-unit id="ssh_connection.php_test_error_message">
 				<source>The test returned following error message:</source>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_root_wrong">
-				<source>The foreign document root could not be validated, because typical TYPO3 folders are missing (option: sshConnection.foreignRootPath).</source>
+				<source>The foreign document root could not be validated, because typical TYPO3 folders are missing (option: foreign.rootPath).</source>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_root_missing">
-				<source>The foreign document root could not be validated, because the configured folder "%s" does not exist (option: sshConnection.foreignRootPath).</source>
+				<source>The foreign document root could not be validated, because the configured folder "%s" does not exist (option: foreign.rootPath).</source>
 			</trans-unit>
 			<trans-unit id="ssh_connection.foreign_document_validation_error">
 				<source>Could not validate the foreign document root for other reasons.</source>


### PR DESCRIPTION
The remote connection test may fail and return an error saying
the »sshConnection.foreignRootPath« needs to be changed.
This setting however was renamed a while ago.

Change the helper labels to show integrators the
correct options instead.