### PR TITLE
[BUGFIX] Ensure array for initialization commands

### DIFF
--- a/Classes/Service/Environment/ForeignEnvironmentService.php
+++ b/Classes/Service/Environment/ForeignEnvironmentService.php
@@ -82,14 +82,14 @@ class ForeignEnvironmentService
 
         $decodedDbInit = [];
         if ($response->isSuccessful()) {
-            $encodedDbInit = 'W10=';
+            $encodedDbInit = 'W10='; // = base64 encoded empty array ("[]")
             foreach ($response->getOutput() as $line) {
                 if (false !== strpos($line, 'DBinit: ')) {
                     $encodedDbInit = GeneralUtility::trimExplode(':', $line)[1];
                     break;
                 }
             }
-            $decodedDbInit = json_decode(base64_decode($encodedDbInit), true);
+            $decodedDbInit = (array)json_decode(base64_decode($encodedDbInit), true);
             $this->cache->set('foreign_db_init', $decodedDbInit, [], 86400);
         } else {
             $this->logger->error(


### PR DESCRIPTION
See issue #56 

The TYPO3 Database Connection requires an array in the setInitializeCommandsAfterConnect method.

The method to generate these commands however may return a string in some cases. To avoid this error I make sure that the returned value is of type array.