### PR TITLE
[FEATURE] Support internal type file_reference (develop)

### DIFF
--- a/Classes/Domain/Service/Processor/GroupProcessor.php
+++ b/Classes/Domain/Service/Processor/GroupProcessor.php
@@ -42,6 +42,7 @@ class GroupProcessor extends AbstractProcessor
     public const INTERNAL_TYPE = 'internal_type';
     public const INTERNAL_TYPE_DB = 'db';
     public const INTERNAL_TYPE_FILE = 'file';
+    public const INTERNAL_TYPE_FILE_REFERENCE = 'file_reference';
     public const ALLOWED = 'allowed';
     public const UPLOAD_FOLDER = 'uploadfolder';
 
@@ -95,6 +96,8 @@ class GroupProcessor extends AbstractProcessor
             return $this->canPreProcessInternalTypeDb($config);
         } elseif ($internalType === static::INTERNAL_TYPE_FILE) {
             return $this->canPreProcessInternalTypeFile($config);
+        } elseif($internalType === static::INTERNAL_TYPE_FILE_REFERENCE) {
+            return $this->canPreProcessInternalTypeFileReference($config);
         }
 
         $this->lastReasons[static::INTERNAL_TYPE] = 'The internal type "' . $internalType . '" is not supported';
@@ -110,7 +113,22 @@ class GroupProcessor extends AbstractProcessor
     {
         if (empty($config[static::UPLOAD_FOLDER])) {
             $this->lastReasons[static::INTERNAL_TYPE] =
-                'group internal type file without "uploadfolder" can not be resolved';
+                'The internal type "' . static::INTERNAL_TYPE_FILE . '" is missing an "uploadfolder" and can not be resolved';
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return bool
+     */
+    protected function canPreProcessInternalTypeFileReference(array $config)
+    {
+        if (false === empty($config[static::UPLOAD_FOLDER])) {
+            $this->lastReasons[static::INTERNAL_TYPE] =
+                'The internal type "' . static::INTERNAL_TYPE_FILE_REFERENCE . '" has an unwanted "uploadfolder" and can not be resolved';
             return false;
         }
         return true;


### PR DESCRIPTION
The internal type »file_reference« (eg. used by flux) is supported since version 7.3.0.

Extend this support to regular TCA fields as well.

Patch rebased against development branch (TYPO3 9 & 10).

Refs #69