### PR TITLE
[FEATURE] Docs: Update installation for new core version

### DIFF
--- a/Documentation/Installation/2_Installation.md
+++ b/Documentation/Installation/2_Installation.md
@@ -1,23 +1,39 @@
 # Extension Installation
 
-The installation boils down to three simple steps on both Local and Foreign:
+The installation requires the following steps on both the »Local« and
+»Foreign« system:
 
-1. Copy the source code to typo3conf/ext/in2publish (Please see the in2code GitHub tutorial for more details).
-2. Activate the Extension via Extension Manager
-3. Setup IN2PUBLISH_CONTEXT for the current installation (see [Preparation](1_Preparation.md))
-4. Open the in2publish extension configuration (Click on "in2publish_core" in the Extension Manager) and set the path to your **Configuration.yaml** files (see next chapter for details).
+1. Install the extension in TYPO3
+  - Use the Extension Manager, Composer or a copy of the Git repository
+  - Please take a look at the "in2code GitHub tutorial" if you need more details
+2. Activate the Extension
+3. Set the path to the configuration files of the extension
+  - The configuration files are created next in the chapter "configuration"
+  - TYPO3 < 9: Extensions > "in2publish_core" > Button Configure
+  - TYPO3 >= 9: Settings > Extension Configuration > Button Configure
+    Extensions > "in2publish_core"
+  - Change the value `pathToConfiguration` pointing to the configuration file
+    folder, yet to be created
+4. Make sure the environment variable `IN2PUBLISH_CONTEXT` is set,
+   otherwise the extension modules are not visible
+  - See [Preparation](1_Preparation.md)
 
-## New modules on local
+## New modules on Local
 
 ![Publisher backend modules](_img/modules.png)
 
-If the environment is configured correctly, you will see three or four **new Backend Modules** on Local based on your version of the Content Publisher and its installed expansions.
+If the environment configuration is correct, then you will see three or four
+new backend modules on the »Local« system, based on your version of the
+Content Publisher and it's installed expansions.
 
-## New command controllers in scheduler module on foreign
+»Foreign« won't show any modules, since all module actions are on »Local« only.
+
+## New command controllers in scheduler module on Foreign
 
 ![Command controller list](_img/command_controller.png)
 
-On Foreign there are a couple of new command controllers available.
+On »Foreign« you will see a couple of new command controllers in the
+scheduler module.
 
 ---
 


### PR DESCRIPTION
Explain diffrent extension setting locations for newer TYPO3 versions
and emphasize why the environment variable is needed to see
the different extensions states.