### PR TITLE
[BUGFIX] Use eq() instead of like() for int values

### DIFF
--- a/Classes/Domain/Repository/BaseRepository.php
+++ b/Classes/Domain/Repository/BaseRepository.php
@@ -162,6 +162,8 @@ abstract class BaseRepository
                 $propertyValue[$idx] = $query->getConnection()->quote($value);
             }
             $constraint = $query->expr()->in($propertyName, $propertyValue);
+        } elseif (is_int($propertyValue) || MathUtility::canBeInterpretedAsInteger($propertyValue)) {
+            $constraint = $query->expr()->eq($propertyName, $query->createNamedParameter($propertyValue));
         } else {
             $constraint = $query->expr()->like($propertyName, $query->createNamedParameter($propertyValue));
         }
@@ -246,6 +248,8 @@ abstract class BaseRepository
         foreach ($properties as $propertyName => $propertyValue) {
             if (null === $propertyValue) {
                 $query->andWhere($query->expr()->isNull($propertyName));
+            } elseif (is_int($propertyValue) || MathUtility::canBeInterpretedAsInteger($propertyValue)) {
+                $query->andWhere($query->expr()->eq($propertyName, $query->createNamedParameter($propertyValue)));
             } else {
                 $query->andWhere($query->expr()->like($propertyName, $query->createNamedParameter($propertyValue)));
             }


### PR DESCRIPTION
When applied, this commit will add usage of eq() comparison instead of like() when processing integer values during record collection.
Improves performance by 98% as measured with blackfire profiling.

Fixes #84 