### PR TITLE
[BUGFIX] Adds extbase property mapping for sys_redirect fields

### DIFF
--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -18,6 +18,10 @@ config.tx_extbase.persistence {
     In2code\In2publishCore\Features\RedirectsSupport\Domain\Model\SysRedirect {
       mapping {
         tableName = sys_redirect
+        columns {
+          tx_in2publishcore_page_uid.mapOnProperty = pageUid
+          tx_in2publishcore_foreign_site_id.mapOnProperty = siteId
+        }
       }
     }
   }


### PR DESCRIPTION
As the configuration in Configuration/Extbase/Persistence/Classes.php has no effect when using TYPO3 v9, the missing database fields mapping makes it impossible to publish and use source host depending redirects. 

This PR adds this field mapping via TypoScript configuration which is needed for TYPO3 v9 only. 

If you've any further questions don't hesitate to drop me a message. 

Best regards,
Marcel 