### PR TITLE
[BUGFIX] Fix type error in FileEdgeCacheInvalidationService class

### DIFF
--- a/Classes/Features/FileEdgeCacheInvalidator/Domain/Service/FileEdgeCacheInvalidationService.php
+++ b/Classes/Features/FileEdgeCacheInvalidator/Domain/Service/FileEdgeCacheInvalidationService.php
@@ -134,8 +134,8 @@ class FileEdgeCacheInvalidationService
             $query->where($query->expr()->in('uid', $recordUidList));
             $query->groupBy('pid');
             $statement = $query->execute();
-            while ($page = $statement->fetch()) {
-                $recordCollection->addRecord('pages', $page);
+            while ($page = $statement->fetchAssociative()) {
+                $recordCollection->addRecord('pages', (int)$page['pid']);
             }
         }
     }


### PR DESCRIPTION
The fetch() method returns an array, but $recordCollection->addRecord() expects an int as 2nd parameter. Furthermore, fetch() has been deprecated in DBAL 2.11. Therefore, fetchAssociative should probably be used here.

Resolves https://github.com/in2code-de/in2publish_core/issues/89