### PR TITLE
[BUGFIX] Split RunningRequest inserts into chunks

### DIFF
--- a/Classes/Domain/Repository/RunningRequestRepository.php
+++ b/Classes/Domain/Repository/RunningRequestRepository.php
@@ -64,7 +64,9 @@ class RunningRequestRepository
     public function flush(): void
     {
         if (!empty($this->inserts)) {
-            $this->connection->bulkInsert(self::RUNNING_REQUEST_TABLE_NAME, $this->inserts);
+            foreach (array_chunk($this->inserts,1000) as $chunk) {
+                $this->connection->bulkInsert(self::RUNNING_REQUEST_TABLE_NAME, $chunk);
+            }
             $this->inserts = [];
         }
     }

--- a/Classes/Domain/Repository/RunningRequestRepository.php
+++ b/Classes/Domain/Repository/RunningRequestRepository.php
@@ -64,7 +64,7 @@ class RunningRequestRepository
     public function flush(): void
     {
         if (!empty($this->inserts)) {
-            foreach (array_chunk($this->inserts,1000) as $chunk) {
+            foreach (array_chunk($this->inserts, 1000) as $chunk) {
                 $this->connection->bulkInsert(self::RUNNING_REQUEST_TABLE_NAME, $chunk);
             }
             $this->inserts = [];


### PR DESCRIPTION
To prevent a `Prepared statement contains too many placeholders` exception, the `inserts` are splitted into chunks.