### PR TITLE
[BUGFIX] Fix units in performance tests

### DIFF
--- a/Classes/Testing/Tests/Performance/DiskSpeedPerformanceTest.php
+++ b/Classes/Testing/Tests/Performance/DiskSpeedPerformanceTest.php
@@ -105,8 +105,8 @@ class DiskSpeedPerformanceTest implements TestCaseInterface
         $writeTime = $readAndWriteTime - $readTime;
 
         $messages = [];
-        $messages[] = 'Read: ' . $readTime . ' msec';
-        $messages[] = 'Write: ' . $writeTime . ' msec';
+        $messages[] = 'Read: ' . round($readTime * 1e6) . ' μs';
+        $messages[] = 'Write: ' . round($writeTime * 1e6) . ' μs';
 
         $severity = TestResult::WARNING;
         if (
@@ -128,7 +128,7 @@ class DiskSpeedPerformanceTest implements TestCaseInterface
             'performance.fs_io.rw_time',
             $severity,
             $messages,
-            [(string)$readAndWriteTime]
+            [(string) round($readAndWriteTime * 1e6)]
         );
     }
 

--- a/Classes/Testing/Tests/Performance/ForeignDbInitializationPerformanceTest.php
+++ b/Classes/Testing/Tests/Performance/ForeignDbInitializationPerformanceTest.php
@@ -68,8 +68,8 @@ class ForeignDbInitializationPerformanceTest implements TestCaseInterface
         $median = (array_sum($times) / count($times));
         $messages = [];
         sort($times);
-        $messages[] = 'Fastest: ' . $times[0] . ' msec';
-        $messages[] = 'Slowest: ' . $times[9] . ' msec';
+        $messages[] = 'Fastest: ' . $times[0] . ' μs';
+        $messages[] = 'Slowest: ' . $times[9] . ' μs';
 
         $severity = TestResult::WARNING;
         if ($median < self::THRESHOLD[TestResult::OK]) {

--- a/Resources/Private/Language/de.locallang.testing.xlf
+++ b/Resources/Private/Language/de.locallang.testing.xlf
@@ -643,8 +643,8 @@
 			<!-- \In2code\In2publishCore\Testing\Tests\Performance\DiskSpeedPerformanceTest -->
 
 			<trans-unit id="performance.fs_io.rw_time">
-				<source>Reading and writing 10 MB took %f microseconds.</source>
-				<target state="translated">Das Lesen und Schreiben von 10 MB hat %f mikrosekunden gedauert.</target>
+				<source>Reading and writing 10 MB took %d microseconds.</source>
+				<target state="translated">Das Lesen und Schreiben von 10 MB hat %d Mikrosekunden gedauert.</target>
 			</trans-unit>
 			<trans-unit id="performance.fs_io.slow_help">
 				<source>

--- a/Resources/Private/Language/de.locallang.testing.xlf
+++ b/Resources/Private/Language/de.locallang.testing.xlf
@@ -621,7 +621,7 @@
 
 			<trans-unit id="performance.db_init.init_time">
 				<source>The foreign database initialization took %d microseconds on average</source>
-				<target state="translated">Die Initialisierung der entfernten benötigt im Schnitt %d Mikrosekunden</target>
+				<target state="translated">Die Initialisierung der entfernten Datenbank benötigt im Schnitt %d Mikrosekunden</target>
 			</trans-unit>
 			<trans-unit id="performance.db_init.slow_help">
 				<source>

--- a/Resources/Private/Language/locallang.testing.xlf
+++ b/Resources/Private/Language/locallang.testing.xlf
@@ -505,7 +505,7 @@
 			<!-- \In2code\In2publishCore\Testing\Tests\Performance\DiskSpeedPerformanceTest -->
 
 			<trans-unit id="performance.fs_io.rw_time">
-				<source>Reading and writing 10 MB took %f microseconds.</source>
+				<source>Reading and writing 10 MB took %d microseconds.</source>
 			</trans-unit>
 			<trans-unit id="performance.fs_io.slow_help">
 				<source>


### PR DESCRIPTION
# Issue

Fixes https://github.com/in2code-de/in2publish_core/issues/88

# Changes

* Both the DB-Init and the disk test are now using microseconds (`μs`) everywhere, instead of a mix of milliseconds (`ms`) and microseconds.
* The translation was updated accordingly, to display an integer instead of a float
* Two German translations were also corrected (capitalized noun and missing word)

### Sidenotes

1. I didn't update the `RceInitializationPerformanceTest` because it is consistent in its use of seconds.
2. We should probably use [`hrtime`](https://www.php.net/manual/en/function.hrtime.php) instead of [`microtime`](https://www.php.net/manual/en/function.microtime), especially now that the extension requires php 7.4 or later. Let me know if you'd like me to implement that change :wink: 