### PR TITLE
[BUGFIX] Require at least a space after the logical operator

### DIFF
--- a/Classes/Utility/DatabaseUtility.php
+++ b/Classes/Utility/DatabaseUtility.php
@@ -232,6 +232,6 @@ class DatabaseUtility
      */
     public static function stripLogicalOperatorPrefix(string $constraint): string
     {
-        return preg_replace('/^(?:(AND|OR)[[:space:]]*)+/i', '', trim($constraint)) ?: '';
+        return preg_replace('/^(?:(AND|OR)[[:space:]]+)+/i', '', trim($constraint)) ?: '';
     }
 }


### PR DESCRIPTION
Fixes https://github.com/in2code-de/in2publish_core/issues/113

This prevents operators that starts with `AND` or `OR` (such as `ORDER`) from being striped, resulting in incorrect SQL syntax.