### PR TITLE
[BUGFIX] Prevent exceptions for non existing tables

### DIFF
--- a/Classes/Component/Core/Service/Database/TableContentService.php
+++ b/Classes/Component/Core/Service/Database/TableContentService.php
@@ -120,9 +120,15 @@ class TableContentService implements SingletonInterface
 
     protected function queryTableFromDatabase(Connection $connection, string $table): array
     {
-        $quotedTable = $connection->quoteIdentifier($table);
-        $rows = $connection->executeQuery("SELECT DISTINCT `pid` FROM $quotedTable;")->fetchAllAssociative();
-        return array_column($rows, 'pid');
+        try {
+            $quotedTable = $connection->quoteIdentifier($table);
+            $rows = $connection->executeQuery("SELECT DISTINCT `pid` FROM $quotedTable;")->fetchAllAssociative();
+            return array_column($rows, 'pid');
+        } catch (Throwable $exception) {
+            // Ignore any errors.
+            // They might indicate that the table does not exist, but that's not this classes' responsibility
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
Same as for the `isEmpty()` method, should this function not trigger exceptions on non existing tables.