### PR TITLE
[BUGFIX] Fix filters in file module

### DIFF
--- a/Resources/Public/JavaScript/BackendModule.js
+++ b/Resources/Public/JavaScript/BackendModule.js
@@ -9,7 +9,9 @@ define([
 	'TYPO3/CMS/In2publishCore/ConfirmationModal',
 ], function ($, DebounceEvent, Modal, LoadingOverlay, ConfirmationModal) {
 	var In2publishCoreModule = {
-		isPublishFilesModule: (document.querySelector('.module[data-module-name="file_In2publishCoreM3"]') !== null),
+		isPublishFilesModule: (document.querySelector('.module[data-module-name="in2publish_core_m3"]') !== null)
+			// TYPO3 v11
+			|| (document.querySelector('.module[data-module-name="file_In2publishCoreM3"]') !== null),
 		unchangedFilter: false,
 		changedFilter: false,
 		addedFilter: false,


### PR DESCRIPTION
Currently, the filtering in the file upload backend module is broken for TYPO3 v12. This seems to be caused by a changed module identifier for the new backend module configuration. This adds the new identifier so that the correct initialization is run.