### PR TITLE
[BUGFIX] Fix cache clear task

### DIFF
--- a/Classes/Features/CacheInvalidation/Domain/Model/Task/FlushFrontendPageCacheTask.php
+++ b/Classes/Features/CacheInvalidation/Domain/Model/Task/FlushFrontendPageCacheTask.php
@@ -68,8 +68,13 @@ class FlushFrontendPageCacheTask extends AbstractTask
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         /** @var CommandLineUserAuthentication $user */
         $user = $GLOBALS['BE_USER'];
-        $user->authenticate();
+
+        if (!$user->user) {
+            $user->authenticate();
+        }
+
         $dataHandler->BE_USER = $user;
+
         /** @psalm-suppress InternalProperty */
         $dataHandler->admin = true;
         return $dataHandler;


### PR DESCRIPTION
The task to clear caches related to files results in abnormal termination of the program. This is caused because the DataHandler used to clear caches expects the [BE_USER to either be null or fully authenticated](https://github.com/TYPO3/typo3/blob/v12.4.19/typo3/sysext/core/Classes/DataHandling/DataHandler.php#L9350) (without authenticate, BE_USER->user will be null and BE_USER->user['username'] will crash).

This fix copies over the existing logic to authenticate from the other cache clear task. It also adds a condition ensuring the authentication logic runs only once, as a second authentication is redundant if both tasks get executed.

It may be worth it to alternatively authenticate the users in the CLI command(s). We are alternatively aware of some issues regarding flash messages on failure, for example, which we have disabled due to no authentication taking place in various commands.