### PR TITLE
[BUGFIX] Fix publishbackgroundall dependency index

### DIFF
--- a/Classes/Component/Core/DemandResolver/Select/SelectDemandResolver.php
+++ b/Classes/Component/Core/DemandResolver/Select/SelectDemandResolver.php
@@ -100,8 +100,11 @@ class SelectDemandResolver implements DemandResolver
                     if (null === $record) {
                         continue;
                     }
-                    $recordCollection->addRecord($record);
+                } else {
+                    $this->recordIndex->addRecord($record);
                 }
+
+                $recordCollection->addRecord($record);
                 $localMapValue = $record->getLocalProps()[$property] ?? null;
                 $foreignMapValue = $record->getForeignProps()[$property] ?? null;
                 $mapValues = array_unique([$localMapValue, $foreignMapValue]);


### PR DESCRIPTION
The command in2publish:workflow:publishbackground from the premium plugin may skip pages depending on previous pages:

 1. Assume a page and a child page are scheduled for publishing.
 2. Assume the child page gets processed first.
 3. The child page will fetch the parent page as a dependency. The parent page will get recorded in the index.
 4. When the parent page record gets fetched from the database, it will already be in the index. It will not get added to any record index recording.
 5. The RecordTreeBuilder assumes that pages scheduled for publishing get added to the record index recording buildRecordTree, which did not happen in step 4.
 6. The parent page gets marked as published, but changes will not actually have been published.

This commit ensures the parent page gets added to the buildRecordTree record index recording. It archives that by adding pages to the record index recording even if it was already in the index.

As this code is pretty deep, I am not quite sure about unintended side effects. Intense testing is advisable.