### PR TITLE
[TASK] Improve cache handling

### DIFF
--- a/Classes/Features/CacheInvalidation/Domain/Model/Task/FlushFrontendPageCacheTask.php
+++ b/Classes/Features/CacheInvalidation/Domain/Model/Task/FlushFrontendPageCacheTask.php
@@ -56,7 +56,22 @@ class FlushFrontendPageCacheTask extends AbstractTask
         $dataHandler = $this->getDataHandler();
         $commands = GeneralUtility::trimExplode(',', $this->configuration['pid'], true);
         foreach ($commands as $command) {
-            $dataHandler->clear_cacheCmd($command);
+            // This is the same method ultimately called as if we changed the
+            // DataBase via DataHandler. This means it is also the same logic
+            // used as the backend.
+            // This is @internal. However, it does more processing than
+            // any public api.
+            $dataHandler->registerRecordIdForPageCacheClearing(
+                'pages',
+                $command,
+            );
+        }
+
+        // We want to call $dataHandler->processClearCacheQueue().
+        // That function is protected, so we have to do it indirectly.
+        $dataHandler->process_cmdmap();
+
+        foreach ($commands as $command) {
             $this->addMessage('Cleared frontend cache with configuration clearCacheCmd=' . $command);
         }
         return true;


### PR DESCRIPTION
As of now, in2publish only clears the cache of all published changes. This is not the same behaviour as used in the core. This can cause the following problem:

 1. Create a page with a menu_menu_subpages element.
 2. Publish that page.
 3. View that page on the foreign system.
 4. Create a child page on local.
 5. Observe the menu_menu_subpages listing the child page on local.
 6. Publish the child page.
 7. Observe the menu_menu_subpages not listing the child page on foreign.

To view the page in the menu_menu_subpages, you need to clear frontend caches on foreign.

This patch changes the behaviour of in2publish to mirror that of the backend. In order to do that, internal functionality is used.