### PR TITLE
[BUGFIX] Avoid trailing AND when additionalWhere is empty

### DIFF
--- a/Classes/Component/Core/PreProcessing/PreProcessor/SelectProcessor.php
+++ b/Classes/Component/Core/PreProcessing/PreProcessor/SelectProcessor.php
@@ -89,12 +89,12 @@ class SelectProcessor extends AbstractProcessor
             }
             $additionalWhere = implode(' AND ', $foreignMatchFields);
             if (1 === preg_match(AbstractProcessor::ADDITIONAL_ORDER_BY_PATTERN, $foreignTableWhere, $matches) && !empty($matches['where'])) {
-                $foreignTableWhere = implode(' AND ', [$matches['where'], $additionalWhere]);
+                $foreignTableWhere = implode(' AND ', array_filter([$matches['where'], $additionalWhere]));
                 if (!empty($matches['col'])) {
                     $foreignTableWhere .= ' ORDER BY ' . $matches['col'] . ($matches['dir'] ?? '');
                 }
             } else {
-                $foreignTableWhere = implode(' AND ', [$foreignTableWhere, $additionalWhere]);
+                $foreignTableWhere = implode(' AND ', array_filter([$foreignTableWhere, $additionalWhere]));
             }
             $foreignTableWhere = DatabaseUtility::stripLogicalOperatorPrefix($foreignTableWhere);
             $foreignTableWhere = $this->tcaEscapingMarkerService->escapeMarkedIdentifier($foreignTableWhere);


### PR DESCRIPTION
# Issue

Upgrading to `12.5.8` prevents publishing pages because in some cases the generated SQL queries are incorrect:

```sql
SELECT 
  `tx_news_domain_model_news_tag_mm`.`uid_local` AS `mmtbl_uid_local`, 
  `tx_news_domain_model_news_tag_mm`.`uid_foreign` AS `mmtbl_uid_foreign`, 
  `tx_news_domain_model_news_tag_mm`.`sorting` AS `mmtbl_sorting`, 
  `tx_news_domain_model_news_tag_mm`.`sorting_foreign` AS `mmtbl_sorting_foreign`, 
  `tx_news_domain_model_tag`.`uid` AS `table_uid`, `tx_news_domain_model_tag`.`pid` AS `table_pid`, 
  `tx_news_domain_model_tag`.`tstamp` AS `table_tstamp`, 
  `tx_news_domain_model_tag`.`crdate` AS `table_crdate`, 
  `tx_news_domain_model_tag`.`cruser_id` AS `table_cruser_id`, 
  `tx_news_domain_model_tag`.`deleted` AS `table_deleted`, 
  `tx_news_domain_model_tag`.`hidden` AS `table_hidden`, 
  `tx_news_domain_model_tag`.`sys_language_uid` AS `table_sys_language_uid`, 
  `tx_news_domain_model_tag`.`l10n_parent` AS `table_l10n_parent`, 
  `tx_news_domain_model_tag`.`l10n_diffsource` AS `table_l10n_diffsource`, 
  `tx_news_domain_model_tag`.`l10n_source` AS `table_l10n_source`, 
  `tx_news_domain_model_tag`.`notes` AS `table_notes`, 
  `tx_news_domain_model_tag`.`l10n_state` AS `table_l10n_state`, 
  `tx_news_domain_model_tag`.`t3ver_oid` AS `table_t3ver_oid`, 
  `tx_news_domain_model_tag`.`t3ver_wsid` AS `table_t3ver_wsid`, 
  `tx_news_domain_model_tag`.`t3ver_state` AS `table_t3ver_state`, 
  `tx_news_domain_model_tag`.`t3ver_stage` AS `table_t3ver_stage`, 
  `tx_news_domain_model_tag`.`sorting` AS `table_sorting`, 
  `tx_news_domain_model_tag`.`title` AS `table_title`, 
  `tx_news_domain_model_tag`.`slug` AS `table_slug`, 
  `tx_news_domain_model_tag`.`seo_title` AS `table_seo_title`, 
  `tx_news_domain_model_tag`.`seo_description` AS `table_seo_description`, 
  `tx_news_domain_model_tag`.`seo_headline` AS `table_seo_headline`, 
  `tx_news_domain_model_tag`.`seo_text` AS `table_seo_text` 
FROM `tx_news_domain_model_news_tag_mm` 
LEFT JOIN `tx_news_domain_model_tag` `tx_news_domain_model_tag` 
ON tx_news_domain_model_news_tag_mm.uid_foreign = tx_news_domain_model_tag.uid 
WHERE (`uid_local` IN (5, 2, 764)) 
AND (
  (
    tx_news_domain_model_tag.sys_language_uid IN (-1,0) 
    OR tx_news_domain_model_tag.l10n_parent = 0
  ) 
  AND 
) 
ORDER BY `tx_news_domain_model_tag`.`title` ASC'
```

It seems to happen when additionalWhere is an empty string.

# Changes

Restoring the `array_filter` ensures empty strings will not be considered when joining conditions with ` AND `.