### PR TITLE
[BUGFIX] Fix parenthesis logic in isRemovedAndDeletedRecord method

### DIFF
--- a/Classes/Component/Core/Record/Factory/RecordFactory.php
+++ b/Classes/Component/Core/Record/Factory/RecordFactory.php
@@ -168,6 +168,6 @@ class RecordFactory
         if (null === $deleteField) {
             return false;
         }
-        return (empty($record->getLocalProps() && 1 === (int)$record->getForeignProps()[$deleteField]));
+        return (empty($record->getLocalProps()) && 1 === (int)$record->getForeignProps()[$deleteField]);
     }
 }


### PR DESCRIPTION
# Issue

Updating to v12.7.0, no more pages are displayed in the Publish Overview. 

Versions: 

TYPO3 v12.4.38, 
in2publish_core v12.7.0 
in2publish v12.4.5, no more re

# Changes

The parenthesis were fixed, so `empty` checks only `$record->getLocalProps()` (instead of the `&&` of it with an extra condition)