### PR TITLE
[BUGFIX] Allow to publish translated pages when unpublished deleted translations exist

### DIFF
--- a/Classes/Listener/DeletedUnpublishedTranslationsExistForThisPage.php
+++ b/Classes/Listener/DeletedUnpublishedTranslationsExistForThisPage.php
@@ -70,7 +70,7 @@ class DeletedUnpublishedTranslationsExistForThisPage
 
         $deletedUids = array_column($deletedTranslationsLocal, 'uid');
 
-        // Check which of these deleted translations exist on foreign
+        // Check which of these deleted translations still exist on foreign
         $foreignQuery = $this->foreignDatabase->createQueryBuilder();
         $foreignQuery->getRestrictions()->removeAll();
         $deletedTranslationsForeign = $foreignQuery->select('uid', $deleteField)
@@ -79,17 +79,13 @@ class DeletedUnpublishedTranslationsExistForThisPage
                                                        $foreignQuery->expr()->in(
                                                            'uid',
                                                            $foreignQuery->createNamedParameter($deletedUids, ArrayParameterType::INTEGER)
-                                                       )
+                                                       ),
+                                                       $foreignQuery->expr()->eq($deleteField, 0)
                                                    )
                                                    ->executeQuery()
                                                    ->fetchAllAssociative();
 
-        $foreignUids = array_column($deletedTranslationsForeign, 'uid');
-
-        // Find deleted translations that exist locally but not on foreign
-        // These unpublished deletions should be published first
-        // https://projekte.in2code.de/issues/72213
-        $unpublishedDeletedTranslations = array_diff($deletedUids, $foreignUids);
+        $unpublishedDeletedTranslations = array_column($deletedTranslationsForeign, 'uid');
 
         if (!empty($unpublishedDeletedTranslations)) {
             $event->addReason(

--- a/Classes/Listener/DeletedUnpublishedTranslationsExistForThisPage.php
+++ b/Classes/Listener/DeletedUnpublishedTranslationsExistForThisPage.php
@@ -62,30 +62,26 @@ class DeletedUnpublishedTranslationsExistForThisPage
                                                    $localQuery->expr()->neq('uid', $localQuery->createNamedParameter($currentRecord, \PDO::PARAM_INT)),
                                                )
                                                ->executeQuery()
-                                               ->fetchAllAssociative();
+                                               ->fetchFirstColumn();
 
         if (empty($deletedTranslationsLocal)) {
             return;
         }
 
-        $deletedUids = array_column($deletedTranslationsLocal, 'uid');
-
         // Check which of these deleted translations still exist on foreign
         $foreignQuery = $this->foreignDatabase->createQueryBuilder();
         $foreignQuery->getRestrictions()->removeAll();
-        $deletedTranslationsForeign = $foreignQuery->select('uid', $deleteField)
+        $unpublishedDeletedTranslations = $foreignQuery->select('uid', $deleteField)
                                                    ->from($recordTable)
                                                    ->where(
                                                        $foreignQuery->expr()->in(
                                                            'uid',
-                                                           $foreignQuery->createNamedParameter($deletedUids, ArrayParameterType::INTEGER)
+                                                           $foreignQuery->createNamedParameter($deletedTranslationsLocal, ArrayParameterType::INTEGER)
                                                        ),
                                                        $foreignQuery->expr()->eq($deleteField, 0)
                                                    )
                                                    ->executeQuery()
-                                                   ->fetchAllAssociative();
-
-        $unpublishedDeletedTranslations = array_column($deletedTranslationsForeign, 'uid');
+                                                   ->fetchFirstColumn();
 
         if (!empty($unpublishedDeletedTranslations)) {
             $event->addReason(


### PR DESCRIPTION
# Issue

This MR fixes the issue reported on https://projekte.in2code.de/issues/77190 :

> It is not possible to publish a new translated page if a previous unpublished page has been deleted.

> ## How to reproduce
> 
> - Create a page and publish
> - Create a translation - do NOT publish
> - Delete the translation
> - Create a new translation
> - Try to publish the new translation => not possible

# Changes

* The `select` on Foreign records now specifically targets records that are deleted on local but not on foreign
   * The `array_diff` operation was removed, since locally deleted translations that were never published (or hard-deleted) on foreign should not block the publication of translations
* Cleanup: use `fetchFirstColumn` instead of chaining `fetchAllAssociative` + `array_column`

| Before | After |
| --- | --- |
| <img width="1116" height="204" alt="image" src="https://github.com/user-attachments/assets/3dc559e2-87a7-4cf4-bc1f-050941f6ab19" /> | <img width="1116" height="157" alt="image" src="https://github.com/user-attachments/assets/9e04a30f-3adf-4579-ae07-48806544ecb6" /> |

Also, it seems the changes introduced with https://projekte.in2code.de/issues/72213 now work as expected for our setup
 (TYPO3 v12.4.40, in2publish_core 12.7.1, in2publish 12.4.5 with deactivated workflows):

>  - create page in default language and publish
>  - create translated page and publish
>  - delete page translation ( do not publish deletion)
>  - create new page translation

| Before | After |
| --- | --- |
| <img width="1116" height="210" alt="image" src="https://github.com/user-attachments/assets/9c09242e-3b81-4333-bddf-635670ff0bb1" /> | <img width="1116" height="255" alt="image" src="https://github.com/user-attachments/assets/fdc64551-82ec-423d-aed7-980c9fa8a6f3" /> |

# Sidenote

The suggested solution (as well as the previous logic) will not consider locally hard-deleted translations (the translations was hard-deleted on local, but still exists and isn't soft-deleted on foreign).

Not sure if this is a possibly relevant use-case, and if a new Listener should be created to deal with it, or if the current Listener should be extended to deal with all possible cases.