### PR TITLE
[BUGFIX] Use stricter typing when comparing records

### DIFF
--- a/Classes/Component/Core/Publisher/DatabaseRecordPublisher.php
+++ b/Classes/Component/Core/Publisher/DatabaseRecordPublisher.php
@@ -7,8 +7,7 @@ namespace In2code\In2publishCore\Component\Core\Publisher;
 use In2code\In2publishCore\CommonInjection\ForeignDatabaseReconnectedInjection;
 use In2code\In2publishCore\Component\Core\Record\Model\AbstractDatabaseRecord;
 use In2code\In2publishCore\Component\Core\Record\Model\Record;
-
-use function array_diff_assoc;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 
 class DatabaseRecordPublisher implements Publisher, TransactionalPublisher
 {
@@ -37,7 +36,7 @@ class DatabaseRecordPublisher implements Publisher, TransactionalPublisher
         }
 
         $foreignProps = $record->getForeignProps();
-        $newValues = array_diff_assoc($localProps, $foreignProps);
+        $newValues = ArrayUtility::arrayDiffAssocRecursive($localProps, $foreignProps);
         if (!empty($newValues)) {
             $this->foreignDatabase->update($table, $newValues, $foreignIdentificationProps);
         }

--- a/Classes/Component/Core/Record/Factory/RecordFactory.php
+++ b/Classes/Component/Core/Record/Factory/RecordFactory.php
@@ -42,6 +42,7 @@ use In2code\In2publishCore\Component\Core\RecordIndexInjection;
 use In2code\In2publishCore\Event\DecideIfRecordShouldBeIgnored;
 use In2code\In2publishCore\Event\RecordWasCreated;
 use In2code\In2publishCore\Service\Configuration\IgnoredFieldsServiceInjection;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RecordFactory
@@ -154,7 +155,7 @@ class RecordFactory
         return null !== $deleteField
             && array_key_exists($deleteField, $record->getLocalProps())
             && $record->getLocalProps()[$deleteField]
-            && !count(array_diff_assoc($record->getLocalProps(), $record->getForeignProps()));
+            && !count(ArrayUtility::arrayDiffAssocRecursive($record->getLocalProps(), $record->getForeignProps()));
     }
 
     protected function isRemovedAndDeletedRecord(Record $record): bool

--- a/Classes/Component/Core/Record/Model/AbstractRecord.php
+++ b/Classes/Component/Core/Record/Model/AbstractRecord.php
@@ -15,9 +15,9 @@ use LogicException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function array_diff_assoc;
 use function array_diff_key;
 use function array_flip;
 use function array_keys;
@@ -184,7 +184,7 @@ abstract class AbstractRecord implements Record
         $ignoredProps = array_flip($this->ignoredProps);
         $relevantLocalProps = array_diff_key($this->localProps, $ignoredProps);
         $relevantForeignProps = array_diff_key($this->foreignProps, $ignoredProps);
-        return array_keys(array_diff_assoc($relevantLocalProps, $relevantForeignProps));
+        return array_keys(ArrayUtility::arrayDiffAssocRecursive($relevantLocalProps, $relevantForeignProps));
     }
 
     protected function calculateState(): string


### PR DESCRIPTION
# Issue

`array_diff_assoc` checks for (in)equality but doesn't use strict typing:

```php
var_dump(array_diff_assoc([0 => ''], [0 => null])); // array(0) {}
```

This is an issue, for example when working with `sys_file_reference`: a `NULL` "Element specific values" will cause the default value to be used, whereas an empty string will replace it (by an empty string).

<img width="612" height="349" alt="image" src="https://github.com/user-attachments/assets/224f1abb-85c3-4d4a-b372-7fb29f30763b" />

It is currently impossible to publish an empty string as specific value when the record was previously published with the checkbox unchecked, since both values are considered identical by the ContentPublisher.

# Changes

Using TYPO3s `ArrayUtility::arrayDiffAssocRecursive` instead of `array_diff_assoc` ensures exact typing is checked (`$value !== $array2[$key]`).

:information_source: As the name suggests, the method also supports nested arrays, which we do not need in this particular scenario. If performance is more important than code reusability, it would also be possible to create a custom method in the extension utility class:

```php
namespace In2code\In2publishCore\Utility;

class ArrayUtility
{
    // …
   
    public static function arrayDiffAssoc(array $array1, array $array2): array
    {
        $differenceArray = [];
        foreach ($array1 as $key => $value) {
            if (!array_key_exists($key, $array2) || $value !== $array2[$key]) {
                $differenceArray[$key] = $value;
            }
        }
        return $differenceArray;
    }
```

# How to test

1. Create a ContentElement containing a reference to an image (`sys_file_reference`)
2. Publish it
3. Edit the created ContentElement and check all `Set element specific value` checkboxes, but leave the fields empty
4. Open the Publish Overview: changes should be reflected and publishable